### PR TITLE
Fakerでユニークな値を生成可能に

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -16,17 +16,17 @@ final class Builder
     /** @var array */
     private $using_recipes = [];
 
-    /** @var string */
-    private $locale;
-
     /** @var int */
     private $times = 1;
+
+    /** @var \Faker\Generator */
+    private $faker;
 
     public function __construct(callable $callable_for_make, array $recipes, string $locale)
     {
         $this->callable_for_make = $callable_for_make;
         $this->recipes = $recipes;
-        $this->locale = $locale;
+        $this->faker = \Faker\Factory::create($locale);
 
         $this->recipe(Factory::DEFAULT);
     }
@@ -94,7 +94,7 @@ final class Builder
         }
 
         if (is_callable($recipe)) {
-            return $recipe(\Faker\Factory::create($this->locale));
+            return $recipe($this->faker);
         }
 
         throw new InvalidArgumentException('recipe must be array or callable.');

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Yahiru\EntityFactory\Tests;
 
 use Faker\Generator;
+use OverflowException;
 use PHPUnit\Framework\TestCase;
 use Yahiru\EntityFactory\Factory;
 
@@ -67,5 +68,32 @@ final class FactoryTest extends TestCase
         $this->assertSame('define1', Factory::of('define1')->make());
         $this->assertSame('define2', Factory::of('define2')->make());
         $this->assertSame('define3', Factory::of('define3')->make());
+    }
+
+
+    public function testGenerateUniqueValue()
+    {
+        Factory::define(
+            'Number',
+            function (array $attr) {
+                return $attr['num'];
+            },
+            function (\Faker\Generator $faker): array {
+                return [
+                    'num' => $faker->unique->randomDigit,
+                ];
+            }
+        );
+
+        $nums = Factory::of('Number')->times(10)->make();
+        $digits = range(0, 9);
+        foreach ($nums as $num) {
+            assert(array_key_exists($num, $digits));
+            unset($digits[$num]);
+        }
+        $this->assertEmpty($digits);
+
+        $this->expectException(OverflowException::class);
+        Factory::of('Number')->times(11)->make();
     }
 }


### PR DESCRIPTION
Close #1 

Fakerでユニークな値を生成できるようにしました。
以前はBuiderクラスがFakerインスタンスを毎回生成するため、ユニークの値であるか？のキャッシュが記録されませんでした。

```php
<?php
Factory::define(
    'Number',
    function (array $attr) {
        return $attr['num'];
    },
    function (\Faker\Generator $faker): array {
        return [
            'num' => $faker->unique->randomDigit,
        ];
    }
);
```