### PR TITLE
レシピのクロージャに$currentAttributesを渡す

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ class FooEntityFactory extends AbstractFactory
 
     public function fakerRecipe(): self
     {
-        $this->addRecipe(function (Faker $faker) {
+        $this->addRecipe(function (Faker $faker, array $currentAttributes) {
             return [
                 'name' => $faker->name
             ];

--- a/src/AbstractFactory.php
+++ b/src/AbstractFactory.php
@@ -114,7 +114,7 @@ abstract class AbstractFactory
         /** @var Recipe[] $recipes */
         foreach ($recipes as $recipe) {
             $this->updateCurrentAttributes(
-                $built = array_merge($built, $recipe->toAttribute($faker))
+                $built = array_merge($built, $recipe->toAttribute($faker, $this->currentAttributes))
             );
         }
 

--- a/src/Recipe.php
+++ b/src/Recipe.php
@@ -26,12 +26,12 @@ final class Recipe
         $this->recipe = $recipe;
     }
 
-    public function toAttribute(Faker $faker): array
+    public function toAttribute(Faker $faker, array $currentAttributes): array
     {
         if (is_array($this->recipe)) {
             return $this->recipe;
         }
 
-        return ($this->recipe)($faker);
+        return ($this->recipe)($faker, $currentAttributes);
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -115,11 +115,10 @@ final class FactoryTest extends TestCase
             public $current;
             public function testingRecipe()
             {
-                $this->addRecipe(function (Generator $faker) {
-                    $this->current = $this->currentAttributes();
+                $this->addRecipe(function (Generator $faker, array $currentAttributes) {
+                    $this->current = $currentAttributes;
                     return [];
                 });
-
                 return $this;
             }
         };

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -126,20 +126,4 @@ final class FactoryTest extends TestCase
 
         $this->assertSame(['name' => 'testing name'], $factory->current);
     }
-
-    public function testResetCurrentAttributes()
-    {
-        $factory = new class extends FakeEntityFactory {
-            public $currents = [];
-            protected function default(Generator $faker): array
-            {
-                $this->currents[] = $this->currentAttributes();
-                return parent::default($faker);
-            }
-        };
-        $factory->times(2)->make();
-
-        $this->assertSame([], $factory->currents[0]);
-        $this->assertSame([], $factory->currents[1]);
-    }
 }


### PR DESCRIPTION
ファクトリークラスが持つメソッドaddRecipeにクロージャを渡した場合、引数に現在のパラメータを受け取るように変更しました。
レシピメソッドをimmutableで実装できるようにするためです。

```php
$this->addRecipe(function (Generator $faker, array $currentAttributes) use ($name) {
    return ['name' => 'hoge'];
});
```